### PR TITLE
Improve build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Platform Compatibility Analyzer
 
-[![Build status](https://ci.appveyor.com/api/projects/status/evecxgd6lnsg20lb/branch/master?svg=true)](https://ci.appveyor.com/project/terrajobst/platform-compat/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/llhi1p4filksoibf/branch/master?svg=true)](https://ci.appveyor.com/project/terrajobst/platform-compat/branch/master)
 
 This tool provides [Roslyn](https://github.com/dotnet/roslyn) analyzers that
 find usages of .NET Core & .NET Standard APIs that are problematic on specific

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,23 @@
 @echo off
+setlocal
+
+:: Use VSINSTALLDIR if present
+
+if not "%VSINSTALLDIR%" == "" goto setmsbuild
+
+:: Use vswhere to find an install of VS 2017
+
+set VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist %VSWHERE% goto error
+for /f "tokens=*" %%i in ('%VSWHERE% -property installationPath') do set VSINSTALLDIR=%%i
+
+:setmsbuild
 
 set MSBuild="%VSINSTALLDIR%\MSBuild\15.0\Bin\MSBuild.exe"
+if exist %MSBuild% goto build
+
+:error
+
 if exist %MSBuild% goto build
 echo ERROR: You need Visual Studio 2017 to build.
 exit /B -1

--- a/build.cmd
+++ b/build.cmd
@@ -11,4 +11,4 @@ setlocal
 set OutDir="%~dp0bin"
 
 if not exist %OutDir% mkdir %OutDir%
-%MSBuild% /nologo /m /v:m /nr:false /flp:logfile=bin\msbuild.log;verbosity=normal /t:Restore /t:Build /p:OutDir=%OutDir% %*
+%MSBuild% /nologo /m /v:m /nr:false /bl:%OutDir%\msbuild.binlog /t:Restore /t:Build /p:OutDir=%OutDir% %*


### PR DESCRIPTION
* Enable binary logger
* Allow `build.cmd` to be called outside of a VS developer command prompt