### PR TITLE
Fix upgrade warnings for System.Composition

### DIFF
--- a/src/PlatformCompat.Cci/PlatformCompat.Cci.csproj
+++ b/src/PlatformCompat.Cci/PlatformCompat.Cci.csproj
@@ -6,6 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools.Cci" Version="1.0.0-prerelease-01423-01" />
+
+    <!-- Suppress warning for upgrade from 1.0.30 to 1.0.31 -->
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Hosting" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Runtime" Version="1.0.31" />
+    <PackageReference Include="System.Composition.TypedParts" Version="1.0.31" />
   </ItemGroup>
 
 </Project>

--- a/src/PlatformCompat.Scanner.Tests/PlatformCompat.Scanner.Tests.csproj
+++ b/src/PlatformCompat.Scanner.Tests/PlatformCompat.Scanner.Tests.csproj
@@ -8,6 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
+
+    <!-- Suppress warning for upgrade from 1.0.30 to 1.0.31 -->
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Hosting" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Runtime" Version="1.0.31" />
+    <PackageReference Include="System.Composition.TypedParts" Version="1.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlatformCompat.Scanner/PlatformCompat.Scanner.csproj
+++ b/src/PlatformCompat.Scanner/PlatformCompat.Scanner.csproj
@@ -7,6 +7,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools.Cci" Version="1.0.0-prerelease-01423-01" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+
+    <!-- Suppress warning for upgrade from 1.0.30 to 1.0.31 -->
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Hosting" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Runtime" Version="1.0.31" />
+    <PackageReference Include="System.Composition.TypedParts" Version="1.0.31" />
   </ItemGroup>
 
 </Project>

--- a/src/dep-index/dep-index.csproj
+++ b/src/dep-index/dep-index.csproj
@@ -8,6 +8,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools.Cci" Version="1.0.0-prerelease-01423-01" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+
+    <!-- Suppress warning for upgrade from 1.0.30 to 1.0.31 -->
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Hosting" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Runtime" Version="1.0.31" />
+    <PackageReference Include="System.Composition.TypedParts" Version="1.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ex-gen/ex-gen.csproj
+++ b/src/ex-gen/ex-gen.csproj
@@ -9,6 +9,12 @@
     <PackageReference Include="Microsoft.DotNet.BuildTools.Cci" Version="1.0.0-prerelease-01423-01" />
     <PackageReference Include="SharpCompress" Version="0.15.2" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+
+    <!-- Suppress warning for upgrade from 1.0.30 to 1.0.31 -->
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Hosting" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Runtime" Version="1.0.31" />
+    <PackageReference Include="System.Composition.TypedParts" Version="1.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ex-scan/ex-scan.csproj
+++ b/src/ex-scan/ex-scan.csproj
@@ -8,6 +8,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools.Cci" Version="1.0.0-prerelease-01423-01" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+
+    <!-- Suppress warning for upgrade from 1.0.30 to 1.0.31 -->
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Hosting" Version="1.0.31" />
+    <PackageReference Include="System.Composition.Runtime" Version="1.0.31" />
+    <PackageReference Include="System.Composition.TypedParts" Version="1.0.31" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This project uses assets from our build tools feed which apparently no longer has a specific version of System.Composition (1.0.30).

This causes NuGet to produce warnings. Since that's annoying, I've suppressed the warnings by explicitly upgrading the project to System.Composition (1.0.31).