### PR TITLE
Remove explicit package reference to NETStandard.Library

### DIFF
--- a/src/PlatformCompat.Analyzers.Tests/PlatformCompat.Analyzers.Tests.csproj
+++ b/src/PlatformCompat.Analyzers.Tests/PlatformCompat.Analyzers.Tests.csproj
@@ -17,7 +17,6 @@
        in the NuGet cache so we can pass references to our test compilation. -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0-preview1-25205-01" ExcludeAssets="All" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.0-preview1-25207-01" ExcludeAssets="All" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.4.0-beta-24913-02" ExcludeAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
The package now comes from the SDK.