### PR TITLE
WIP: Add deprecation information for GetTypeInfo() and TypeInfo

### DIFF
--- a/docs/DE0008.md
+++ b/docs/DE0008.md
@@ -1,0 +1,42 @@
+<!--
+T:System.Reflection.TypeInfo
+M:System.Reflection.IntrospectionExtensions.GetTypeInfo(System.Type)
+T:System.Reflection.IReflectableType
+M:System.Reflection.IReflectableType.GetTypeInfo
+-->
+
+# DE0008: TypeInfo shouldn't be used
+
+## Motivation
+
+When we designed .NET Standard 1.0 we wanted to split reflection from the very
+core of the platform. The goal was to allow the creation of .NET platforms that
+do not have reflection capabilities. We assumed this would drastically simplify
+development of an ahead-of-time (AOT) compiler.
+
+We later learned that (1) .NET without reflection isn't really viable in
+practice and (2) that AOT and reflection aren't as much at odds as we originally
+thought.
+
+In order to separate the platform core from reflection we had to break the
+dependency from `Object` to reflection. We did this by making `Type` essentially
+free of reflection APIs and introduced a new type called `TypeInfo`. In APIs,
+there was no relationship between `Type` and `TypeInfo` -- customers doing
+reflection in .NET Standard 1.x had to call `GetTypeInfo()` in order to get a
+full reflection object (`TypeInfo`) from a given `Type`.
+
+With .NET Standard 2.0 we've added all the reflection APIs back to `Type` and
+made `TypeInfo` derive from it. This effectively undoes the split between
+`System.Type` and reflection, rendering both `GetTypeInfo()` as well as
+`TypeInfo` superfluous.
+
+## Recommendation
+
+We recommend that new code follows what code prior to .NET Standard 1.x did all
+along: just use `GetType()` and call reflection APIs right from `System.Type`:
+
+* Do not call `IntrospectionExtensions.GetTypeInfo(Type)` or
+  `IReflectableType.GetTypeInfo()`. Instead, just operate on the instance of
+  `Type`.
+* Do not accept or return instances of `TypeInfo` or `IReflectableType` from
+  your APIs. Instead, just accept or return `Type`.

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -22,5 +22,9 @@ T:System.Net.HttpWebRequest,System.Net,HttpWebRequest,,DE0003
 T:System.Net.WebClient,System.Net,WebClient,,DE0004
 T:System.Net.WebRequest,System.Net,WebRequest,,DE0003
 T:System.Net.Mail.SmtpClient,System.Net.Mail,SmtpClient,,DE0005
+M:System.Reflection.IntrospectionExtensions.GetTypeInfo(System.Type),System.Reflection,IntrospectionExtensions,GetTypeInfo(Type),DE0008
+T:System.Reflection.IReflectableType,System.Reflection,IReflectableType,,DE0008
+M:System.Reflection.IReflectableType.GetTypeInfo,System.Reflection,IReflectableType,GetTypeInfo(),DE0008
+T:System.Reflection.TypeInfo,System.Reflection,TypeInfo,,DE0008
 T:System.Security.SecureString,System.Security,SecureString,,DE0001
 N:System.Security.Permissions,System.Security.Permissions,,,DE0002

--- a/src/PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -216,5 +216,56 @@ namespace PlatformCompat.Analyzers.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Fact]
+        public void DeprecatedAnalyzer_Triggers_DE0008_GetTypeInfo()
+        {
+            var source = @"
+                using System;
+                using System.Reflection;
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        {{var}} typeinfo = typeof(Main).{{GetTypeInfo}}();
+                    }
+                }
+            ";
+
+            var expected = $@"
+                DE0008: TypeInfo is deprecated
+                DE0008: IntrospectionExtensions.GetTypeInfo(Type) is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
+
+        [Fact]
+        public void DeprecatedAnalyzer_Triggers_DE0008_IReflectableType()
+        {
+            var source = @"
+                using System;
+                using System.Reflection;
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        {{var}} reflectableType = typeof(Main) as {{IReflectableType}};
+                        {{var}} typeInfo = reflectableType.{{GetTypeInfo}}();
+                    }
+                }
+            ";
+
+            var expected = $@"
+                DE0008: IReflectableType is deprecated
+                DE0008: IReflectableType is deprecated
+                DE0008: TypeInfo is deprecated
+                DE0008: IReflectableType.GetTypeInfo() is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
     }
 }


### PR DESCRIPTION
We should probably also make the tool smart enough to not display this warning if the `System.Type` provided by the platform doesn't expose reflection APIs.

We can do this by either support a condition for deprecation that is based on whether other APIs exist (e.g. `Type.GetMembers()`) or by marking this issue as only relevant for specific target frameworks.

* [ ] Ensure warning only triggers when replacement API is present
* [x] Agree with @dotnet/fxdc that we're OK with deprecating these APIs
* [x] Add tests
