### PR TITLE
Add "About XXX" fixer

### DIFF
--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/MetaCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/MetaCodeFixProvider.cs
@@ -17,9 +17,9 @@ using Microsoft.DotNet.Analyzers.Compatibility.Net461;
 
 namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ReportIssueCodeFixProvider))]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MetaCodeFixProvider))]
     [Shared]
-    public sealed class ReportIssueCodeFixProvider : CodeFixProvider
+    public sealed class MetaCodeFixProvider : CodeFixProvider
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds
         {

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/MetaCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/MetaCodeFixProvider.cs
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
 
             public override Task<object> GetPreviewAsync(CancellationToken cancellationToken)
             {
-                return Task.FromResult<object>(string.Format(Resources.BrowseToUrl, Url));
+                return Task.FromResult<object>(string.Format(Resources.BrowseToUrlFormat, Url));
             }
         }
     }

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -68,6 +68,12 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
                 var result = new[] { new OpenInBrowserOperation(Url) };
                 return Task.FromResult<IEnumerable<CodeActionOperation>>(result);
             }
+
+            protected override Task<IEnumerable<CodeActionOperation>> ComputePreviewOperationsAsync(CancellationToken cancellationToken)
+            {
+                var result = new[] { new OpenInBrowserPreviewOperation(Url) };
+                return Task.FromResult<IEnumerable<CodeActionOperation>>(result);
+            }
         }
 
         private sealed class OpenInBrowserOperation : CodeActionOperation
@@ -94,6 +100,21 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
                                                 m.GetParameters()[0].ParameterType == typeof(string));
 
                 startMethod.Invoke(null, new[] { Url });
+            }
+        }
+
+        private sealed class OpenInBrowserPreviewOperation : PreviewOperation
+        {
+            public OpenInBrowserPreviewOperation(string url)
+            {
+                Url = url;
+            }
+
+            public string Url { get; }
+
+            public override Task<object> GetPreviewAsync(CancellationToken cancellationToken)
+            {
+                return Task.FromResult<object>(string.Format(Resources.BrowseToUrl, Url));
             }
         }
     }

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -37,7 +37,6 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var diagnostic = context.Diagnostics.First();
-            var diagnosticSpan = diagnostic.Location.SourceSpan;
 
             RegisterReportIssue(context, diagnostic);
             RegisterAbout(context, diagnostic);

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -39,16 +39,21 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
+            RegisterReportIssue(context, diagnostic);
+
+            return Task.CompletedTask;
+        }
+
+        private static void RegisterReportIssue(CodeFixContext context, Diagnostic diagnostic)
+        {
             var issueTitle = $"{diagnostic.Id}: {diagnostic.GetMessage()}";
             var issueTitleEncoded = WebUtility.UrlEncode(issueTitle);
             var url = $"https://github.com/dotnet/platform-compat/issues/new?title={issueTitleEncoded}";
 
             var action = new OpenInBrowserAction(Resources.ReportAnIssueTitle, url);
             context.RegisterCodeFix(action, diagnostic);
-
-            return Task.CompletedTask;
         }
-        
+
         private sealed class OpenInBrowserAction : CodeAction
         {
             public OpenInBrowserAction(string title, string url)

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -50,7 +50,8 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
             var issueTitleEncoded = WebUtility.UrlEncode(issueTitle);
             var url = $"https://github.com/dotnet/platform-compat/issues/new?title={issueTitleEncoded}";
 
-            var action = new OpenInBrowserAction(Resources.ReportAnIssueTitle, url);
+            var title = string.Format(Resources.ReportAnIssueFormatString, diagnostic.Id);
+            var action = new OpenInBrowserAction(title, url);
             context.RegisterCodeFix(action, diagnostic);
         }
 

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -36,10 +36,11 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var diagnostic = context.Diagnostics.First();
-
-            RegisterReportIssue(context, diagnostic);
-            RegisterAbout(context, diagnostic);
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                RegisterReportIssue(context, diagnostic);
+                RegisterAbout(context, diagnostic);
+            }
 
             return Task.CompletedTask;
         }

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -38,22 +38,11 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                RegisterReportIssue(context, diagnostic);
                 RegisterAbout(context, diagnostic);
+                RegisterReportIssue(context, diagnostic);
             }
 
             return Task.CompletedTask;
-        }
-
-        private static void RegisterReportIssue(CodeFixContext context, Diagnostic diagnostic)
-        {
-            var issueTitle = $"{diagnostic.Id}: {diagnostic.GetMessage()}";
-            var issueTitleEncoded = WebUtility.UrlEncode(issueTitle);
-            var url = $"https://github.com/dotnet/platform-compat/issues/new?title={issueTitleEncoded}";
-
-            var title = string.Format(Resources.ReportAnIssueFormatString, diagnostic.Id);
-            var action = new OpenInBrowserAction(title, url);
-            context.RegisterCodeFix(action, diagnostic);
         }
 
         private static void RegisterAbout(CodeFixContext context, Diagnostic diagnostic)
@@ -63,6 +52,17 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
                 return;
 
             var title = string.Format(Resources.AboutDiagnosticFormatString, diagnostic.Id);
+            var action = new OpenInBrowserAction(title, url);
+            context.RegisterCodeFix(action, diagnostic);
+        }
+
+        private static void RegisterReportIssue(CodeFixContext context, Diagnostic diagnostic)
+        {
+            var issueTitle = $"{diagnostic.Id}: {diagnostic.GetMessage()}";
+            var issueTitleEncoded = WebUtility.UrlEncode(issueTitle);
+            var url = $"https://github.com/dotnet/platform-compat/issues/new?title={issueTitleEncoded}";
+
+            var title = string.Format(Resources.ReportAnIssueFormatString, diagnostic.Id);
             var action = new OpenInBrowserAction(title, url);
             context.RegisterCodeFix(action, diagnostic);
         }

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -40,6 +40,7 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
             RegisterReportIssue(context, diagnostic);
+            RegisterAbout(context, diagnostic);
 
             return Task.CompletedTask;
         }
@@ -51,6 +52,17 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
             var url = $"https://github.com/dotnet/platform-compat/issues/new?title={issueTitleEncoded}";
 
             var action = new OpenInBrowserAction(Resources.ReportAnIssueTitle, url);
+            context.RegisterCodeFix(action, diagnostic);
+        }
+
+        private static void RegisterAbout(CodeFixContext context, Diagnostic diagnostic)
+        {
+            var url = diagnostic.Descriptor.HelpLinkUri;
+            if (string.IsNullOrEmpty(url))
+                return;
+
+            var title = string.Format(Resources.AboutDiagnosticFormatString, diagnostic.Id);
+            var action = new OpenInBrowserAction(title, url);
             context.RegisterCodeFix(action, diagnostic);
         }
 

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Fixes/ReportIssueCodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Fixes
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ReportIssueCodeFixProvider))]
     [Shared]
-    public class ReportIssueCodeFixProvider : CodeFixProvider
+    public sealed class ReportIssueCodeFixProvider : CodeFixProvider
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds
         {

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.DotNet.Analyzers.Compatibility {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to About {0}.
+        /// </summary>
+        internal static string AboutDiagnosticFormatString {
+            get {
+                return ResourceManager.GetString("AboutDiagnosticFormatString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Browse to {0}.
         /// </summary>
         internal static string BrowseToUrl {

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.DotNet.Analyzers.Compatibility {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse to {0}.
+        /// </summary>
+        internal static string BrowseToUrl {
+            get {
+                return ResourceManager.GetString("BrowseToUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DocId,Namespace,Type,Member,DiagnosticIds
         ///F:System.PlatformID.MacOSX,System,PlatformID,MacOSX,DE0007
         ///F:System.PlatformID.Win32S,System,PlatformID,Win32S,DE0007

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
@@ -217,11 +217,11 @@ namespace Microsoft.DotNet.Analyzers.Compatibility {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Report an issue.
+        ///   Looks up a localized string similar to Report an issue with {0}.
         /// </summary>
-        internal static string ReportAnIssueTitle {
+        internal static string ReportAnIssueFormatString {
             get {
-                return ResourceManager.GetString("ReportAnIssueTitle", resourceCulture);
+                return ResourceManager.GetString("ReportAnIssueFormatString", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.Designer.cs
@@ -73,9 +73,9 @@ namespace Microsoft.DotNet.Analyzers.Compatibility {
         /// <summary>
         ///   Looks up a localized string similar to Browse to {0}.
         /// </summary>
-        internal static string BrowseToUrl {
+        internal static string BrowseToUrlFormat {
             get {
-                return ResourceManager.GetString("BrowseToUrl", resourceCulture);
+                return ResourceManager.GetString("BrowseToUrlFormat", resourceCulture);
             }
         }
         

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AboutDiagnosticFormatString" xml:space="preserve">
+    <value>About {0}</value>
+  </data>
   <data name="BrowseToUrl" xml:space="preserve">
     <value>Browse to {0}</value>
   </data>

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
@@ -120,7 +120,7 @@
   <data name="AboutDiagnosticFormatString" xml:space="preserve">
     <value>About {0}</value>
   </data>
-  <data name="BrowseToUrl" xml:space="preserve">
+  <data name="BrowseToUrlFormat" xml:space="preserve">
     <value>Browse to {0}</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BrowseToUrl" xml:space="preserve">
+    <value>Browse to {0}</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Deprecated" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\etc\deprecated.csv;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Resources.resx
@@ -168,7 +168,7 @@
     <value>API not available in .NET Framework 4.6.1</value>
     <comment>The title of the diagnostic.</comment>
   </data>
-  <data name="ReportAnIssueTitle" xml:space="preserve">
-    <value>Report an issue</value>
+  <data name="ReportAnIssueFormatString" xml:space="preserve">
+    <value>Report an issue with {0}</value>
   </data>
 </root>


### PR DESCRIPTION
We already have a code fixer that let's us report issues. This adds a fixer that allows jumping to the documentation. Part of this work also includes some changes that results from using two code actions that both do similar things (i.e. opening the web browser). This includes a preview text that describes this action opens a web browser.

![image](https://user-images.githubusercontent.com/5169960/31857130-5762d21c-b68a-11e7-9c36-091e5397d90f.png)

