### PR TITLE
improve text

### DIFF
--- a/docs/DE0008.md
+++ b/docs/DE0008.md
@@ -7,12 +7,12 @@ P:System.Threading.Thread.CurrentUICulture
 
 ## Motivation
 
-These properties don't work consistently across OSes and runtimes when used against 
+These properties don't work consistently across operating systems and runtimes when used against 
 any thread other than the current thread.
 
-* In .NET Core an `InvalidOperationException` is thrown if a thread tries
+* In .NET Core, an `InvalidOperationException` is thrown if a thread tries
 to read or write these properties on a different thread.
-* In .NET Framework setting these properties is not reliable for a different thread. 
+* In .NET Framework, setting these properties isn't reliable for a different thread. 
 
 ## Recommendation
 


### PR DESCRIPTION
@pjanotti just saw the request for review now. Proposing some grammar changes based on that.

The plural of OS is OSs, which I find very ugly and easy to confuse with OSS, so I tend to spell it out.