### PR TITLE
Properties can be assigned via backing field

### DIFF
--- a/src/Microsoft.DotNet.Analyzers.Compatibility.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility.Tests/DeprecatedAnalyzerTests.cs
@@ -265,5 +265,33 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Fact]
+        public void DeprecatedAnalyzer_OkWithAutomaticProperties()
+        {
+            var source = @"
+                namespace platform_compatAD0001
+                {
+                    public class Test
+                    {
+                        public sealed class InnerTest
+                        {
+                            public bool Valid { get; set; } = false;
+                        }
+
+                        public bool Valid { get; }
+
+                        public Test(InnerTest innertest)
+                        {
+                            Valid = innertest.Valid;
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/SymbolUsageAnalysisExtensions.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/SymbolUsageAnalysisExtensions.cs
@@ -170,7 +170,11 @@ namespace Microsoft.DotNet.Analyzers.Compatibility
                     isSetter = true;
                 }
 
+                // It is possible that neither the setter nor the getter actually exists but the null check after this block takes care of that.
+                // For the cases that we are interested the method must exist, direct operations on backing fields are not interesting to our analysis.
                 symbol = isSetter ? propertySymbol.SetMethod : propertySymbol.GetMethod;
+                if (symbol == null)
+                    return;
             }
 
             // We don't want to check symbols defined in source.


### PR DESCRIPTION
The code was assuming the presence of a setter if the property was on the left side of an attribution, but that can be done via a backing field in some special cases. The analyzer should ignore such cases since they are not coming from the properties, and respective getters and setters, that we are interested.

Fixes #96
