### PR TITLE
Certain symbols can have null containing type and/or namespace

### DIFF
--- a/src/Microsoft.DotNet.Analyzers.Compatibility.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility.Tests/DeprecatedAnalyzerTests.cs
@@ -293,5 +293,30 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Fact]
+        public void DeprecatedAnalyzer_Ok_With_Pointers()
+        {
+            var source = @"
+                namespace platform_compatAD0001
+                {
+                    public unafe class Test
+                    {
+                        int CountUntilNull(IntPtr pStart) 
+                        {
+                            var cnt = 0;
+                            var p = (byte*)pStart;
+                            while (*p++ != 0)
+                                ++cnt;
+                            return cnt;
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Analyzers.Compatibility/Store/ApiStore.cs
+++ b/src/Microsoft.DotNet.Analyzers.Compatibility/Store/ApiStore.cs
@@ -67,7 +67,8 @@ namespace Microsoft.DotNet.Analyzers.Compatibility.Store
                 case SymbolKind.Method:
                 case SymbolKind.Property:
                     var memberName = IsConstructor(symbol) ? ".ctor" : symbol.Name;
-                    return (symbol.ContainingNamespace.Name, symbol.ContainingType.Name, memberName);
+                    // Certain symbols, e.g.: pointer op_Increment, do not have containing type or namespace, send those as null. 
+                    return (symbol.ContainingNamespace?.Name, symbol.ContainingType?.Name, memberName);
 
                 default:
                     return (null, null, null);


### PR DESCRIPTION
The case in question was specifically about pointer, but the fix deals with the more general scenario.

Fixes #99