### PR TITLE
Updated code sample to match new macOS syntax

### DIFF
--- a/docs/PC001.md
+++ b/docs/PC001.md
@@ -39,7 +39,7 @@ run your code on like in the following example:
 
 ```XML
 <PropertyGroup>
-    <PlatformCompatIgnore>Linux;MacOSX</PlatformCompatIgnore>
+    <PlatformCompatIgnore>Linux;macOS</PlatformCompatIgnore>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
#78 changed "MacOSX" to "macOS", but that code sample has not been changed accordingly.