### PR TITLE
Win exception thrown by System.IO.Directory.Move now thrown in Unix

### DIFF
--- a/etc/exceptions.csv
+++ b/etc/exceptions.csv
@@ -2130,6 +2130,7 @@ M:System.IdentityModel.Selectors.X509SecurityTokenAuthenticator.ValidateTokenCor
 "M:System.IdentityModel.Tokens.SecurityTokenException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.IdentityModel.Tokens,SecurityTokenException,".ctor(SerializationInfo, StreamingContext)",X,X,
 "M:System.IdentityModel.Tokens.SecurityTokenValidationException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.IdentityModel.Tokens,SecurityTokenValidationException,".ctor(SerializationInfo, StreamingContext)",X,X,
 M:System.IdentityModel.Tokens.X509SecurityToken.get_SecurityKeys,System.IdentityModel.Tokens,X509SecurityToken,get_SecurityKeys(),X,X,
+M:System.IO.Directory.Move(System.String,System.String),System.IO,Directory,Move(System.String,System.String),X,X,X
 M:System.IO.DriveInfo.set_VolumeLabel(System.String),System.IO,DriveInfo,set_VolumeLabel(String),X,X,
 "M:System.IO.DriveInfo.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.IO,DriveInfo,"System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo, StreamingContext)",X,X,X
 M:System.IO.File.Decrypt(System.String),System.IO,File,Decrypt(String),X,X,X


### PR DESCRIPTION
It was suggested to me in issue https://github.com/dotnet/corefx/issues/33486 to make this update to indicate that an exception that was being thrown in Windows only, is now going to be thrown in Unix too.

Please let me know if the change was done in the right place and with the correct format.