### PR TITLE
Update link location

### DIFF
--- a/docs/PC002.md
+++ b/docs/PC002.md
@@ -29,4 +29,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Usage", "PC002:API not available in .NET Framework 4.6.1", Justification = "This library will not run on .NET Framework 4.6.1")]
 ```
 
-[netfx-netstandard]: https://github.com/dotnet/standard/blob/master/docs/netstandard-20/README.md#net-framework-461-supporting-net-standard-20
+[netfx-netstandard]: https://github.com/dotnet/standard/blob/master/docs/planning/netstandard-2.0/README.md#net-framework-461-supporting-net-standard-20


### PR DESCRIPTION
Referenced file in the dotnet/standard repo was moved from docs to docs/planning. The #anchorTarget has survived.